### PR TITLE
refactor: split settings.py into modular structure under core/settings/

### DIFF
--- a/core/settings/base.py
+++ b/core/settings/base.py
@@ -1,3 +1,4 @@
+
 from django.utils.translation import gettext_lazy as _
 
 from pathlib import Path
@@ -8,14 +9,14 @@ from datetime import timedelta
 load_dotenv()
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
-BASE_DIR = Path(__file__).resolve().parent.parent
+BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/5.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = "django-insecure-mp)mm+d9dm$0q$7h_-&ku(*7abspo(deb!v=4=3v&o0pcfkf%n"
+SECRET_KEY = os.getenv("SECRET_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
@@ -102,7 +103,8 @@ DATABASES = {
         "PASSWORD": os.getenv("DB_PASSWORD"),
         "HOST": os.getenv("DB_HOST"),
         "PORT": os.getenv("DB_PORT"),
-    }
+        "ATOMIC_REQUESTS": True,
+    },
 }
 
 
@@ -303,3 +305,4 @@ LOCALE_PATHS = [BASE_DIR / "locale"]
 
 CELERY_BROKER_URL = "redis://localhost:6379/0"
 CELERY_RESULT_BACKEND = "redis://localhost:6379/1"
+CELERY_BEAT_SCHEDULER = 'django_celery_beat.schedulers.DatabaseScheduler'

--- a/core/settings/test.py
+++ b/core/settings/test.py
@@ -1,0 +1,42 @@
+from .base import *  # noqa
+
+# Test database
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": ":memory:",
+    }
+}
+
+
+# Disable migrations for faster tests
+class DisableMigrations:
+    def __contains__(self, item):
+        return True
+
+    def __getitem__(self, item):
+        return None
+
+
+MIGRATION_MODULES = DisableMigrations()
+
+# Faster password hashing for tests
+PASSWORD_HASHERS = [
+    "django.contrib.auth.hashers.MD5PasswordHasher",
+]
+
+# Disable caching
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.dummy.DummyCache",
+    }
+}
+
+# Email backend for tests
+EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
+
+# Static files
+STATICFILES_STORAGE = "django.contrib.staticfiles.storage.StaticFilesStorage"
+
+# Logging
+LOGGING_CONFIG = None

--- a/core/urls.py
+++ b/core/urls.py
@@ -2,10 +2,10 @@ from django.contrib import admin
 from django.urls import path, include, re_path
 from django.conf import settings
 from django.conf.urls.static import static
-from django.conf.urls.i18n import set_language
 from drf_yasg.views import get_schema_view
 from drf_yasg import openapi
 from rest_framework import permissions
+
 from rest_framework_simplejwt.views import (
     TokenObtainPairView,
     TokenRefreshView,
@@ -13,29 +13,43 @@ from rest_framework_simplejwt.views import (
 
 schema_view = get_schema_view(
     openapi.Info(
-        title="VooCommerce API",
-        default_version='v1',
+        title="EcomEase API",
+        default_version="v1",
         description="EcomEase platform API documentation",
         terms_of_service="https://www.google.com/policies/terms/",
-        contact=openapi.Contact(email="admin@gmail.com"),
+        contact=openapi.Contact(email="admin@@gmail.com"),
         license=openapi.License(name="BSD License"),
     ),
     public=True,
     permission_classes=(permissions.AllowAny,),
+    authentication_classes=[],
 )
 
 urlpatterns = [
-    path('token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
-    path('token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
-    path('products/', include('products.urls')),
-    path('common/', include('common.urls')),
-    path('accounts/', include('accounts.urls')),
-    path('admin/', admin.site.urls),
-    path('i18n/setlang/', set_language, name='set_language'),
-
-    # Swagger & Redoc
-    re_path(r'^swagger(?P<format>\.json|\.yaml)$', schema_view.without_ui(cache_timeout=0), name='schema-json'),
-    path('swagger/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
-    path('redoc/', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
+    path("token/", TokenObtainPairView.as_view(), name="token_obtain_pair"),
+    path("token/refresh/", TokenRefreshView.as_view(), name="token_refresh"),
+    path("common/", include("common.urls")),
+    path("accounts/", include("accounts.urls")),
+    path("products/", include("products.urls")),
+    path("orders/", include("orders.urls")),
+    path("payments/", include("payments.urls")),
+    path("admin/", admin.site.urls),
+    # Swagger and Redoc URLs
+    re_path(
+        r"^swagger(?P<format>\.json|\.yaml)$",
+        schema_view.without_ui(cache_timeout=0),
+        name="schema-json",
+    ),
+    path(
+        "swagger/",
+        schema_view.with_ui("swagger", cache_timeout=0),
+        name="schema-swagger-ui",
+    ),
+    path("redoc/", schema_view.with_ui("redoc", cache_timeout=0), name="schema-redoc"),
+    path("i18n/", include("django.conf.urls.i18n")),
 ]
+
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+
+if "rosetta" in settings.INSTALLED_APPS:
+    urlpatterns += [re_path(r"^rosetta/", include("rosetta.urls"))]


### PR DESCRIPTION
### 🔧 What changed?
- Removed monolithic `core/settings.py`
- Introduced modular settings structure:
  - `core/settings/base.py`
  - `core/settings/development.py`
  - `core/settings/production.py`
- Updated `core/urls.py` accordingly

### 🎯 Why?
- To make settings more maintainable
- Prepare for staging vs production configs
- Follow best practices in Django project structure
