### PR TITLE
feat: add initial order model fields, choices, urls, and API base structure...

### DIFF
--- a/orders/api_endpoints/Checkout/__init__.py
+++ b/orders/api_endpoints/Checkout/__init__.py
@@ -1,0 +1,3 @@
+from .views import CheckoutAPIView
+
+__all__ = ["CheckoutAPIView"]

--- a/orders/api_endpoints/Checkout/serializers.py
+++ b/orders/api_endpoints/Checkout/serializers.py
@@ -1,0 +1,21 @@
+from rest_framework import serializers
+
+from orders.choices import CheckoutSourceChoices
+from orders.api_endpoints.Checkout.services import create_order
+
+
+class CheckoutSerializer(serializers.Serializer):
+    id = serializers.IntegerField(read_only=True)
+    source = serializers.ChoiceField(
+        choices=CheckoutSourceChoices.choices, required=True, write_only=True
+    )
+    product = serializers.IntegerField(write_only=True, required=False)
+    quantity = serializers.IntegerField(write_only=True, required=False)
+
+    def create(self, validated_data):
+        created_order = create_order(**validated_data)
+        if not create_order:
+            raise serializers.ValidationError(
+                "Order could not be created: ambiguous source."
+            )
+        return created_order

--- a/orders/api_endpoints/Checkout/services.py
+++ b/orders/api_endpoints/Checkout/services.py
@@ -1,0 +1,48 @@
+from accounts.models import User
+from orders.models import Order, OrderItem
+from products.models import ProductVariant
+from orders.choices import CheckoutSourceChoices
+from common.choices import OrderStatus
+
+
+def create_order(source: str, user: User, product: int = None, quantity: int = 1):
+    if source == CheckoutSourceChoices.CART:
+        order = Order.objects.create(
+            user=user, total_price=0, status=OrderStatus.PENDING
+        )
+
+        for item in user.cart.cart_items.all():
+            OrderItem.objects.create(
+                order=order,
+                product=item.product,
+                quantity=item.quantity,
+                price=item.product.price * item.quantity,
+            )
+            order.total_price += item.product.price * item.quantity
+
+        order.save()
+
+        for item in user.cart.cart_items.all():
+            item.delete()
+
+        return order
+
+    elif source == CheckoutSourceChoices.PRODUCT:
+        product_obj = ProductVariant.objects.filter(id=product).first()
+        if not product_obj:
+            return None
+
+        order = Order.objects.create(
+            user=user,
+            total_price=product_obj.price * quantity,
+            status=OrderStatus.PENDING,
+        )
+        OrderItem.objects.create(
+            order=order,
+            product=product_obj,
+            quantity=quantity,
+            price=product_obj.price * quantity,
+        )
+        return order
+
+    return None

--- a/orders/api_endpoints/Checkout/views.py
+++ b/orders/api_endpoints/Checkout/views.py
@@ -1,0 +1,15 @@
+from rest_framework.generics import CreateAPIView
+from rest_framework import permissions
+
+from orders.api_endpoints.Checkout.serializers import CheckoutSerializer
+
+
+class CheckoutAPIView(CreateAPIView):
+    permission_classes = [permissions.IsAuthenticated]
+    serializer_class = CheckoutSerializer
+
+    def create(self, request, *args, **kwargs):
+        return super().create(request, *args, **kwargs)
+
+    def perform_create(self, serializer):
+        serializer.save(user=self.request.user)

--- a/orders/api_endpoints/__init__.py
+++ b/orders/api_endpoints/__init__.py
@@ -1,0 +1,3 @@
+from .Checkout import CheckoutAPIView
+
+__all__ = ["CheckoutAPIView"]

--- a/orders/choices.py
+++ b/orders/choices.py
@@ -1,0 +1,6 @@
+from django.db.models import TextChoices
+
+
+class CheckoutSourceChoices(TextChoices):
+    CART = "cart", "Cart"
+    PRODUCT = "product", "Product"

--- a/orders/models.py
+++ b/orders/models.py
@@ -5,20 +5,26 @@ from common.choices import OrderStatus
 
 
 class Order(BaseModel):
-    user = models.ForeignKey('accounts.User', on_delete=models.SET_NULL, null=True, blank=True)
+    user = models.ForeignKey(
+        "accounts.User", on_delete=models.SET_NULL, null=True, blank=True
+    )
     total_price = models.BigIntegerField(null=False, blank=False)
     status = models.CharField(choices=OrderStatus.choices, null=False, blank=False)
     notes = models.CharField(max_length=255, null=True, blank=True)
 
     def __str__(self):
-        return f"Order({self.id})"
+        return f"Order<id={self.id}, price={self.total_price}>"
 
 
 class OrderItem(BaseModel):
-    order = models.ForeignKey('orders.Order', on_delete=models.RESTRICT, null=True, blank=True)
-    product = models.ForeignKey('products.ProductVariant', on_delete=models.RESTRICT, null=True, blank=True)
+    order = models.ForeignKey(
+        "orders.Order", on_delete=models.RESTRICT, null=True, blank=True
+    )
+    product = models.ForeignKey(
+        "products.ProductVariant", on_delete=models.RESTRICT, null=True, blank=True
+    )
     quantity = models.IntegerField(null=False, blank=False)
     price = models.BigIntegerField(null=False, blank=False)
-    
+
     def __str__(self):
-        return f"OrderItem({self.id})"
+        return f"OrderItem<product_id={self.product_id}>"

--- a/orders/urls.py
+++ b/orders/urls.py
@@ -1,0 +1,8 @@
+from django.urls import path
+
+from orders.api_endpoints import CheckoutAPIView
+
+
+urlpatterns = [
+    path("checkout/", CheckoutAPIView.as_view(), name="checkout"),
+]


### PR DESCRIPTION
### 🔧 What changed?
- Added `Order` model fields and structure
- Introduced `choices.py` for order status enums
- Created `orders/urls.py` and registered basic endpoint route
- Created API skeleton folder under `orders/api_endpoints/OrderCreate/`

### 🎯 Why?
Preparing structure for full order placement logic and future CRUD endpoints
